### PR TITLE
Support Deployment to Azure Data Factory v2 SSIS

### DIFF
--- a/src/SsisBuild.Core.Tests/DeployArgumentsTests.cs
+++ b/src/SsisBuild.Core.Tests/DeployArgumentsTests.cs
@@ -29,6 +29,8 @@ namespace SsisBuild.Core.Tests
             var workingFolder = Fakes.RandomString();
             var deploymentFilePath = Fakes.RandomString();
             var serverInstance = Fakes.RandomString();
+            var serverInstanceUserID = Fakes.RandomString();
+            var serverInstancePassword = Fakes.RandomString();
             var catalog = Fakes.RandomString();
             var folder = Fakes.RandomString();
             var projectName = Fakes.RandomString();
@@ -37,12 +39,14 @@ namespace SsisBuild.Core.Tests
 
 
             // Execute
-            var deployArguments = new DeployArguments(workingFolder, deploymentFilePath, serverInstance, catalog, folder, projectName, projectPassword, eraseSensitiveInfo);
+            var deployArguments = new DeployArguments(workingFolder, deploymentFilePath, serverInstance, catalog, folder, projectName, projectPassword, eraseSensitiveInfo, serverInstanceUserID, serverInstancePassword);
 
             // Assert
             Assert.Equal(workingFolder, deployArguments.WorkingFolder);
             Assert.Equal(deploymentFilePath, deployArguments.DeploymentFilePath);
             Assert.Equal(serverInstance, deployArguments.ServerInstance);
+            Assert.Equal(serverInstanceUserID, deployArguments.ServerInstanceUserID);
+            Assert.Equal(serverInstancePassword, deployArguments.ServerInstancePassword);
             Assert.Equal(catalog, deployArguments.Catalog);
             Assert.Equal(folder, deployArguments.Folder);
             Assert.Equal(projectName, deployArguments.ProjectName);
@@ -56,7 +60,7 @@ namespace SsisBuild.Core.Tests
             // Setup
 
             // Execute
-            var exception = Record.Exception(() => new DeployArguments(null, null, null, Fakes.RandomString(), Fakes.RandomString(), Fakes.RandomString(), null, Fakes.RandomBool()));
+            var exception = Record.Exception(() => new DeployArguments(null, null, null, Fakes.RandomString(), Fakes.RandomString(), Fakes.RandomString(), null, Fakes.RandomBool(), null, null));
 
             // Assert
             Assert.NotNull(exception);
@@ -70,7 +74,7 @@ namespace SsisBuild.Core.Tests
             // Setup
 
             // Execute
-            var exception = Record.Exception(() => new DeployArguments(null, null, Fakes.RandomString(), Fakes.RandomString(), null, Fakes.RandomString(), null, Fakes.RandomBool()));
+            var exception = Record.Exception(() => new DeployArguments(null, null, Fakes.RandomString(), Fakes.RandomString(), null, Fakes.RandomString(), null, Fakes.RandomBool(), null, null));
 
             // Assert
             Assert.NotNull(exception);

--- a/src/SsisBuild.Core/Deployer/DeployArguments.cs
+++ b/src/SsisBuild.Core/Deployer/DeployArguments.cs
@@ -18,10 +18,12 @@ namespace SsisBuild.Core.Deployer
 {
     public class DeployArguments : IDeployArguments
     {
-        public DeployArguments(string workingFolder, string deploymentFilePath, string serverInstance, string catalog, string folder, string projectName, string projectPassword, bool eraseSensitiveInfo)
+        public DeployArguments(string workingFolder, string deploymentFilePath, string serverInstance, string catalog, string folder, string projectName, string projectPassword, bool eraseSensitiveInfo, string serverInstanceUserID, string serverInstancePassword)
         {
             DeploymentFilePath = deploymentFilePath;
             ServerInstance = serverInstance;
+            ServerInstanceUserID = serverInstanceUserID;
+            ServerInstancePassword = serverInstancePassword;
             Catalog = catalog;
             Folder = folder;
             ProjectName = projectName;
@@ -36,6 +38,10 @@ namespace SsisBuild.Core.Deployer
         public string DeploymentFilePath { get; }
 
         public string ServerInstance { get; }
+
+        public string ServerInstanceUserID { get; }
+
+        public string ServerInstancePassword { get; }
 
         public string Catalog { get; }
 
@@ -54,6 +60,12 @@ namespace SsisBuild.Core.Deployer
 
             if (string.IsNullOrWhiteSpace(Folder))
                 throw new MissingRequiredArgumentException(nameof(Folder));
+
+            if (string.IsNullOrWhiteSpace(ServerInstancePassword) && !string.IsNullOrWhiteSpace(ServerInstanceUserID))
+                throw new MissingRequiredArgumentException(nameof(ServerInstancePassword));
+
+            if (string.IsNullOrWhiteSpace(ServerInstanceUserID) && !string.IsNullOrWhiteSpace(ServerInstancePassword))
+                throw new MissingRequiredArgumentException(nameof(ServerInstanceUserID));
         }
     }
 }

--- a/src/SsisBuild.Core/Deployer/IDeployArguments.cs
+++ b/src/SsisBuild.Core/Deployer/IDeployArguments.cs
@@ -21,6 +21,8 @@ namespace SsisBuild.Core.Deployer
         string WorkingFolder { get; }
         string DeploymentFilePath { get; }
         string ServerInstance { get; }
+        string ServerInstanceUserID { get; }
+        string ServerInstancePassword { get; }
         string Catalog { get; }
         string Folder { get; }
         string ProjectName { get; }

--- a/src/SsisBuild.Core/Deployer/SsisDeployPowershell.cs
+++ b/src/SsisBuild.Core/Deployer/SsisDeployPowershell.cs
@@ -28,9 +28,17 @@ namespace SsisBuild.Core.Deployer
         )]
         public string DeploymentFilePath { get; set; }
 
-        [Parameter(HelpMessage= "Required. Full Name of the target SQL Server instance.",
+        [Parameter(HelpMessage = "Required. Full Name of the target SQL Server instance.",
                    Mandatory = true)]
         public string ServerInstance { get; set; }
+
+        [Parameter(HelpMessage = "Required. Full Name of the target SQL Server instance.",
+           Mandatory = true)]
+        public string ServerInstanceUserID { get; set; }
+
+        [Parameter(HelpMessage = "Required. Full Name of the target SQL Server instance.",
+           Mandatory = true)]
+        public string ServerInstancePassword { get; set; }
 
         [Parameter(HelpMessage = "Name of the SSIS Catalog on the target server. If not supplied, then SSISDB value is used.")]
         public string Catalog { get; set; }
@@ -71,7 +79,9 @@ namespace SsisBuild.Core.Deployer
                 string.IsNullOrWhiteSpace(Folder) ? null : Folder,
                 string.IsNullOrWhiteSpace(ProjectName) ? null : ProjectName,
                 string.IsNullOrWhiteSpace(ProjectPassword) ? null : ProjectPassword, 
-                EraseSensitiveInfo
+                EraseSensitiveInfo,
+                string.IsNullOrWhiteSpace(ServerInstanceUserID) ? null : ServerInstanceUserID,
+                string.IsNullOrWhiteSpace(ServerInstancePassword) ? null : ServerInstancePassword
             );
 
             _deployer = _deployer ?? new Deployer();

--- a/src/SsisDeploy/Program.cs
+++ b/src/SsisDeploy/Program.cs
@@ -31,6 +31,8 @@ namespace SsisDeploy
             nameof(DeployArguments.ProjectName),
             nameof(DeployArguments.ProjectPassword),
             nameof(DeployArguments.ServerInstance),
+            nameof(DeployArguments.ServerInstanceUserID),
+            nameof(DeployArguments.ServerInstancePassword),
         };
 
 
@@ -69,6 +71,8 @@ namespace SsisDeploy
 
             string deploymentFilePath = null;
             string serverInstance = null;
+            string ServerInstanceUserID = null;
+            string ServerInstancePassword = null;
             string catalog = null;
             string folder = null;
             string projectName = null;
@@ -118,12 +122,20 @@ namespace SsisDeploy
                         projectPassword = args[argPos++ + 1];
                         break;
 
+                    case nameof(DeployArguments.ServerInstanceUserID):
+                        ServerInstanceUserID = args[argPos++ + 1];
+                        break;
+                    
+                    case nameof(DeployArguments.ServerInstancePassword):
+                        ServerInstancePassword = args[argPos++ + 1];
+                        break;
+
                     default:
                         throw new InvalidTokenException(argName);
                 }
             }
 
-            return new DeployArguments(Environment.CurrentDirectory, deploymentFilePath, serverInstance, catalog, folder, projectName, projectPassword, eraseSensitiveInfo);
+            return new DeployArguments(Environment.CurrentDirectory, deploymentFilePath, serverInstance, catalog, folder, projectName, projectPassword, eraseSensitiveInfo, ServerInstanceUserID, ServerInstancePassword);
         }
 
 
@@ -144,6 +156,10 @@ namespace SsisDeploy
                 "                       for a file with ispac extension and uses that file.",
                 "",
                 "  -ServerInstance:     Required. Full Name of the target SQL Server instance.",
+                "",
+                "  -ServerInstanceUserID:  User in case SQL Server Authentication is used (e.g. SSIS in ADFv2)",
+                "",
+                "  -ServerInstancePassword: Password in case SQL Server Authentication is used (e.g. SSIS in ADFv2)",
                 "",
                 "  -Catalog:            Required. Name of the SSIS Catalog on the target server.",
                 "",


### PR DESCRIPTION
To deploy into the data factory support for SQL Authentication is needed. So far the connection string was hard coded to use integrated windows authenticated for SQL Server on premise.
